### PR TITLE
Make AutoPlugin, allow for multiple versions

### DIFF
--- a/src/main/scala/org/nlogo/build/PublishVersioned.scala
+++ b/src/main/scala/org/nlogo/build/PublishVersioned.scala
@@ -1,42 +1,64 @@
+package org.nlogo.build
+
 import sbt._, Keys.{ `package` => packageKey, _ }
 
-object Plugin extends Plugin {
+import sbt.complete.{ Parser, DefaultParsers }, Parser.success, DefaultParsers._
 
-  object PublishVersioned {
+object PublishVersioned extends AutoPlugin {
+  override def trigger = allRequirements
+  override lazy val globalSettings = Seq(commands ++= Seq(packageVersioned, publishVersioned, publishLocalVersioned, packageVersionedCamel, publishVersionedCamel, publishLocalVersionedCamel))
 
-    lazy val settings = Seq(commands ++= Seq(packageVersioned, publishVersioned, publishLocalVersioned, packageVersionedCamel, publishVersionedCamel, publishLocalVersionedCamel))
+  private def packageVersioned      = publishHelper("package-versioned",       packageKey   in Compile)
+  private def publishVersioned      = publishHelper("publish-versioned",       publish      in Compile)
+  private def publishLocalVersioned = publishHelper("publish-local-versioned", publishLocal in Compile)
 
-    private def packageVersioned      = publishHelper("package-versioned",       packageKey   in Compile)
-    private def publishVersioned      = publishHelper("publish-versioned",       publish      in Compile)
-    private def publishLocalVersioned = publishHelper("publish-local-versioned", publishLocal in Compile)
+  private def packageVersionedCamel      = publishHelper("packageVersioned",      packageKey   in Compile)
+  private def publishVersionedCamel      = publishHelper("publishVersioned",      publish      in Compile)
+  private def publishLocalVersionedCamel = publishHelper("publishLocalVersioned", publishLocal in Compile)
 
-    private def packageVersionedCamel      = publishHelper("packageVersioned",      packageKey   in Compile)
-    private def publishVersionedCamel      = publishHelper("publishVersioned",      publish      in Compile)
-    private def publishLocalVersionedCamel = publishHelper("publishLocalVersioned", publishLocal in Compile)
-
-    private def genVersion(isSnapshot: Boolean, version: String): String =
-      if (!isSnapshot)
-        version
-      else {
-        val isClean  = Process("git diff --quiet --exit-code HEAD").! == 0
-        val dirtyStr = if (isClean) "" else "-dirty"
-        val sha      = Process("git rev-parse HEAD").lines.head take 7
-        s"$version-$sha$dirtyStr"
-      }
-
-    private def publishHelper[T](cmdName: String, taskKey: Def.ScopedKey[Task[T]]) = Command.command(cmdName) {
-      state =>
-        val extracted  = Project.extract(state)
-        val isSnap     = extracted.getOpt(isSnapshot).get.asInstanceOf[Boolean]
-        val rawVersion = extracted.getOpt(version).get.asInstanceOf[String]
-        Project.runTask(
-          taskKey,
-          extracted.append(List(version := genVersion(isSnap, rawVersion)), state),
-          true
-        )
-        state
+  private def genVersion(isSnapshot: Boolean, version: String): String =
+    if (!isSnapshot)
+      version
+    else {
+      val isClean  = Process("git diff --quiet --exit-code HEAD").! == 0
+      val dirtyStr = if (isClean) "" else "-dirty"
+      val sha      = Process("git rev-parse HEAD").lines.head take 7
+      s"$version-$sha$dirtyStr"
     }
 
+  private def projectParser(state: State): Parser[ProjectRef] = {
+    val projects = Project.extract(state).structure.allProjectRefs
+    if (projects.length == 1)
+      success(projects.head)
+    else
+      (Space ~> {
+        projects.map(projectRef => (projectRef.project ^^^ projectRef)).reduce(_ | _)
+      }) !!! s"Supply a valid project name. Choices are: ${projects.map(_.project).mkString(", ")}"
   }
 
+  private def commandHelp[T](cmdName: String, taskKey: Def.ScopedKey[Task[T]]): Help =
+    Help(cmdName, (cmdName, "<subproject>"),
+      s"""|$cmdName <subproject>
+          |
+          |  Runs ${taskKey.key.label} in the given subproject.
+          |  If the project is a snapshot, it will supply a version from git.
+          |  Otherwise, the build-specified version will be used for the project.
+          |
+          |  <subproject> may be omitted when there is only one project""".stripMargin)
+
+  private def publishHelper[T](cmdName: String, taskKey: TaskKey[T]) = Command(
+    cmdName, commandHelp(cmdName, taskKey))(projectParser) {
+    (state, subproject) =>
+      val extracted  = Project.extract(state).copy(currentRef = subproject)(Project.extract(state).showKey)
+      val isSnap     = extracted.getOpt(isSnapshot).get.asInstanceOf[Boolean]
+      val rawVersion = extracted.getOpt(version).get.asInstanceOf[String]
+      val evaluationState = extracted.append(
+        List(version := genVersion(isSnap, rawVersion)), state)
+      Project.runTask(
+        taskKey in subproject,
+        extracted.append(List(version := genVersion(isSnap, rawVersion)), state),
+        true
+      )
+      state
+  }
 }


### PR DESCRIPTION
With AutoPlugin, all that is required is the following in `project/plugins.sbt`:

``` scala
addSbtPlugin("org.nlogo" % "publish-versioned-plugin" % "1.1-c436c59")
```

I notice we don't document installation in the README. Perhaps after this is merged and has a version on bintray, we can add a section for that, since it seems most sbt plugins have such a section.

Existing users will need to remove references to `PublishVersioned.settings`, as that no longer exists. If we're adhering strictly to semantic versioning, that would make this a `2.0` release. If we're a bit looser, this should probably be a `1.2` release.

The following errors are shown when used incorrectly

```
> publishLocalVersioned
[error] publishLocalVersioned usage:
[error]   publishLocalVersioned   <subproject>
[error]
[error] publishLocalVersioned
[error]                      ^

> publishLocalVersioned notAProject
[error] Supply a valid project name. Choices are: root, parserJvm, jvmBuild, parserJs, sharedResources, macros, parserCore
[error] publishLocalVersioned notAProject
[error]
```

In addition, when only one project exists in the build, it infers the lone project when the user does not specify one.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/netlogo/publish-versioned-plugin/1)

<!-- Reviewable:end -->
